### PR TITLE
llvm review branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,11 @@
 /*.byte
 /*.docdir
 /*.native
+/Makefile
 /_build/
 /_tags
+/configure
+/doc
 /lib/bap_types/bap_config.ml
 /myocamlbuild.ml
 /postinstall.ml
@@ -28,9 +31,3 @@ _oasis
 /lib/bap_config/bap_config.ml
 /plugins/ida/bap_ida_config.ml
 /plugins/objdump/objdump_config.ml
-arm-binaries
-x86-binaries
-x86_64-binaries
-test-args
-[#]*[#]
-/plugins/_build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testsuite"]
+	path = testsuite
+	url = https://github.com/BinaryAnalysisPlatform/bap-testsuite

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
     - ocaml-nox
     - time
     - aspcud
+    - dejagnu
 
 env:
   - FORK_USER=talex5 FORK_BRANCH=containers OPAMYES=true PACKAGE=bap OCAML_VERSION=latest TESTS=false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 SETUP = ocaml setup.ml -quiet
-PIQI=piqi
-OCI=ocp-indent
 
 build: setup.ml
 	$(SETUP) -build $(BAPBUILDFLAGS)
@@ -35,16 +33,6 @@ distclean:
 .PHONY: clean disclean reinstall
 
 .PHONY: check
-check: check-piqi check-ocp-indent
-
-.PHONY: check-piqi
-check-piqi: *.piqi
-	for piqifile in $^; do $(PIQI) check --strict $$piqifile; done
-
-.PHONY: check-ocp-indent
-check-ocp-indent: *.ml
-	for mlfile in $^; do $(OCI) $$mlfile | diff - $$mlfile; done
-
-.PHONY: auto-ocp-indent
-auto-ocp-indent: *.ml
-	for mlfile in $^; do $(OCI) -i $$mlfile; done
+check:
+	if [ -d .git ]; then git submodule init; git submodule update; fi
+	make -C testsuite

--- a/lib/bap_disasm/disasm.cpp
+++ b/lib/bap_disasm/disasm.cpp
@@ -235,7 +235,6 @@ private:
         dis->step(base + off);
         auto insn = dis->get_insn();
         off = insn.loc.off + insn.loc.len;
-        
         insns.push_back(insn);
         asm_cache.clear();
 

--- a/lib/bap_disasm/disasm.cpp
+++ b/lib/bap_disasm/disasm.cpp
@@ -82,7 +82,7 @@ class disassembler {
     vector<string>  asms;
     string asm_cache;
     vector<predicates> insn_preds;
-    int64_t base;
+    uint64_t base;
     int off;
     bool store_preds, store_asms;
 
@@ -124,7 +124,7 @@ public:
         };
     }
 
-    void set_memory(int64_t addr, const char *data, int offset, int length) {
+    void set_memory(uint64_t addr, const char *data, int offset, int length) {
         this->base = addr;
         this->off  = 0;
         dis->set_memory({data, addr, {offset, length}});
@@ -315,7 +315,7 @@ static inline shared_ptr<disassembler> get(int d) {
 }
 
 
-void bap_disasm_set_memory(int d, int64_t base, const char *data, int off, int len) {
+void bap_disasm_set_memory(int d, uint64_t base, const char *data, int off, int len) {
     get(d)->set_memory(base, data, off, len);
 }
 

--- a/lib/bap_disasm/disasm.h
+++ b/lib/bap_disasm/disasm.h
@@ -144,7 +144,7 @@ const char* bap_disasm_backend_name(int i);
  * */
 void bap_disasm_set_memory(
     bap_disasm_type disasm,
-    int64_t base,
+    uint64_t base,
     const char *data,
     int off,
     int len);

--- a/lib/bap_disasm/disasm.hpp
+++ b/lib/bap_disasm/disasm.hpp
@@ -35,7 +35,7 @@ struct operand;
 // to disassembler, that involves the instruction are undefined.
 struct disassembler_interface {
     // disassemble one instruction, starting from addres \a pc.
-    virtual void step(int64_t pc) = 0;
+    virtual void step(uint64_t pc) = 0;
 
     // directs disassembler to a specifed memory region
     virtual void set_memory(memory) = 0;
@@ -97,7 +97,7 @@ struct insn {
 
 struct memory {
     const char *data;
-    int64_t     base;
+    uint64_t     base;
     location    loc;
 };
 

--- a/lib/bap_disasm/disasm_stubs.c
+++ b/lib/bap_disasm/disasm_stubs.c
@@ -4,6 +4,8 @@
 #include <caml/alloc.h>
 #include <assert.h>
 
+#include <stdint.h>
+
 #include "disasm.h"
 
 

--- a/lib/bap_ida/bap_ida_config.ml
+++ b/lib/bap_ida/bap_ida_config.ml
@@ -1,2 +1,0 @@
-let ida_path = "#undefined"
-let is_headless = false

--- a/opam/opam
+++ b/opam/opam
@@ -74,6 +74,7 @@ install: [
   [make "reinstall"]
   ["bap-byteweight" "update" "--url=https://github.com/BinaryAnalysisPlatform/bap/releases/download/v0.9.9/sigs.zip"]
   [make "test"]
+  [make "check"]
 ]
 
 remove: [

--- a/plugins/api/api/c/posix
+++ b/plugins/api/api/c/posix
@@ -9,7 +9,7 @@ typedef int ldiv_t;
 typedef int lldiv_t;
 typedef int wchar_t;
 
-int main(int argc, const char *argv[]);
+int main(int argc, const char **argv);
 
 // stdlib.h
 

--- a/plugins/llvm/llvm_binary.cpp
+++ b/plugins/llvm/llvm_binary.cpp
@@ -10,7 +10,7 @@ extern "C" {
     }
 
     const char* image_arch(const img::image* m) {
-        return (llvm::Triple::getArchTypeName(m->arch()));
+        return m->arch().c_str();
     }
 
     uint64_t image_entry(const img::image* m) {

--- a/plugins/llvm/llvm_binary.cpp
+++ b/plugins/llvm/llvm_binary.cpp
@@ -10,7 +10,8 @@ extern "C" {
     }
 
     const char* image_arch(const img::image* m) {
-        return m->arch().c_str();
+        //return m->arch().c_str();
+        return (llvm::Triple::getArchTypeName(m->arch()));
     }
 
     uint64_t image_entry(const img::image* m) {

--- a/plugins/llvm/llvm_binary.cpp
+++ b/plugins/llvm/llvm_binary.cpp
@@ -46,59 +46,59 @@ extern "C" {
 
 
     const char* segment_name(const seg::segment* s) {
-        return s->name().c_str();
+        return s->name.c_str();
     }
 
     uint64_t segment_offset(const seg::segment* s) {
-        return s->offset();
+        return s->offset;
     }
 
     uint64_t segment_addr(const seg::segment* s) {
-        return s->addr();
+        return s->addr;
     }
 
     uint64_t segment_size(const seg::segment* s) {
-        return s->size();
+        return s->size;
     }
 
     bool segment_is_readable(const seg::segment* s) {
-        return s->is_readable();
+        return s->is_readable;
     }
 
     bool segment_is_writable(const seg::segment* s) {
-        return s->is_writable();
+        return s->is_writable;
     }
 
     bool segment_is_executable(const seg::segment* s) {
-        return s->is_executable();
+        return s->is_executable;
     }
 
     const char* section_name(const sec::section* s) {
-        return s->name().c_str();
+        return s->name.c_str();
     }
 
     uint64_t section_addr(const sec::section* s) {
-        return s->addr();
+        return s->addr;
     }
 
     uint64_t section_size(const sec::section* s) {
-        return s->size();
+        return s->size;
     }
 
     const char* symbol_name(const sym::symbol* s) {
-        return s->name().c_str();
+        return s->name.c_str();
     }
 
     int symbol_kind(const sym::symbol* s) {
-        return s->kind();
+        return s->kind;
     }
 
     uint64_t symbol_addr(const sym::symbol* s) {
-        return s->addr();
+        return s->addr;
     }
 
     uint64_t symbol_size(const sym::symbol* s) {
-        return s->size();
+        return s->size;
     }
 
 }

--- a/plugins/llvm/llvm_binary.cpp
+++ b/plugins/llvm/llvm_binary.cpp
@@ -10,8 +10,7 @@ extern "C" {
     }
 
     const char* image_arch(const img::image* m) {
-        //return m->arch().c_str();
-        return (llvm::Triple::getArchTypeName(m->arch()));
+        return m->arch().c_str();
     }
 
     uint64_t image_entry(const img::image* m) {

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -427,7 +427,7 @@ uint64_t image_entry(const ELFObjectFile<ELFT>& obj) {
 uint64_t image_entry(const MachOObjectFile& obj) {
     typedef MachOObjectFile::LoadCommandInfo command_info;
     //typedef std::vector<command_info> commands;
-    typedef std::vector<command_info>::const_iterator const_iterator;
+    //typedef std::vector<command_info>::const_iterator const_iterator;
     MachOObjectFile::load_command_iterator it =
         std::find_if(obj.begin_load_commands(), obj.end_load_commands(),
                      [](const command_info &info){

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -155,6 +155,9 @@ struct segment {
 };
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
+using namespace llvm;
+using namespace llvm::object;
+
 template <typename ELFT>
 const typename ELFFile<ELFT>::Elf_Phdr* elf_header_begin(const ELFFile<ELFT> *elf) {
     return elf->program_header_begin();
@@ -169,10 +172,13 @@ iterator_range<MachOObjectFile::load_command_iterator> load_commands(const MachO
     return obj.load_commands();
 }
 
-llvm::object::ObjectFile::section_iterator_range sections(const COFFObjectFile &obj) {
+ObjectFile::section_iterator_range sections(const COFFObjectFile &obj) {
     return obj.sections();
 }
 #else
+using namespace llvm;
+using namespace llvm::object;
+
 template <typename ELFT>
 const typename ELFFile<ELFT>::Elf_Phdr_Iter elf_header_begin(const ELFFile<ELFT> *elf) {
     return elf->begin_program_headers();
@@ -183,8 +189,8 @@ const typename ELFFile<ELFT>::Elf_Phdr_Iter elf_header_end(const ELFFile<ELFT> *
     return elf->end_program_headers();
 }
 
-std::vector<llvm::object::section_iterator> sections(const COFFObjectFile &obj) {
-    std::vector<llvm::object::section_iterator> sections;
+std::vector<section_iterator> sections(const COFFObjectFile &obj) {
+    std::vector<section_iterator> sections;
     for (auto it = obj.begin_sections(); it != obj.end_sections(); ++it) {
         sections.push_back(it);
     }
@@ -443,6 +449,9 @@ struct section {
 };
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
+using namespace llvm;
+using namespace llvm::object;
+
 section make_section(const SectionRef &sec) {
     StringRef name;
     if (error_code ec = sec.getName(name))
@@ -451,14 +460,17 @@ section make_section(const SectionRef &sec) {
     return section{name.str(), sec.getAddress(), sec.getSize()};
 }
 
-llvm::object::section_iterator begin_sections(const ObjectFile &obj) {
+section_iterator begin_sections(const ObjectFile &obj) {
     return obj.sections().begin();
 }
 
-llvm::object::section_iterator end_sections(const ObjectFile &obj) {
+section_iterator end_sections(const ObjectFile &obj) {
     return obj.sections().end();
 }
 #else
+using namespace llvm;
+using namespace llvm::object;
+
 section make_section(const SectionRef &sec) {
     StringRef name;
     if (error_code ec = sec.getName(name))
@@ -474,11 +486,11 @@ section make_section(const SectionRef &sec) {
     return section{name.str(), addr, size};
 }
 
-llvm::object::section_iterator begin_sections(const ObjectFile &obj) {
+section_iterator begin_sections(const ObjectFile &obj) {
     return obj.begin_sections();
 }
 
-llvm::object::section_iterator end_sections(const ObjectFile &obj) {
+section_iterator end_sections(const ObjectFile &obj) {
     return obj.end_sections();
 }
 
@@ -583,24 +595,6 @@ uint64_t image_entry(const MachOObjectFile& obj) {
     }
 }
 #endif
-
-/*
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
-uint64_t getPE32PlusEntry(const COFFObjectFile &obj) {
-    const pe32plus_header *hdr = 0;
-    if (error_code ec = obj.getPE32PlusHeader(hdr))
-        llvm_binary_fail(ec);
-    return hdr->AddressOfEntryPoint;
-}
-#else
-uint64_t getPE32PlusEntry(const COFFObjectFile &obj) {
-    const pe32plus_header *hdr = utils::getPE32PlusHeader(obj);;
-    if (!hdr)
-        llvm_binary_fail("Failed to extract PE32+ header");
-    return hdr->AddressOfEntryPoint;
-}
-#endif
-*/
 
 uint64_t image_entry(const COFFObjectFile& obj) {
     if (obj.getBytesInAddress() == 4) {

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -224,7 +224,7 @@ segment make_segment(T image_base, const coff_section &s) {
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
-llvm::section_iterator_range sections(const COFFObjectFile &obj) {
+llvm::object::ObjectFile::section_iterator_range sections(const COFFObjectFile &obj) {
     return obj.sections();
 }
 #else
@@ -308,7 +308,6 @@ std::vector<symbol> read(const ObjectFile& obj) {
 }
 #else
 // TODO - refactoring this 3.4 code block
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 4
 symbol make_symbol(const SymbolRef &sym) {
     StringRef name;
     if(error_code err = sym.getName(name))
@@ -542,7 +541,7 @@ uint64_t image_entry(const ELFObjectFile<ELFT>& obj) {
     return obj.getELFFile()->getHeader()->e_entry;
 }
 
-// TODO
+/* TODO
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
 llvm::object::MachOObjectFile::load_command_iterator begin_load_commands(const llvm::object::MachOObjectFile &obj) {
     return obj.begin_load_commands();
@@ -560,13 +559,15 @@ int end_load_commands(const MachOObjectFile& obj) {
 
 }
 #endif
+*/
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
 uint64_t image_entry(const MachOObjectFile& obj) {
+    std::cout << "fuck\n";
     typedef MachOObjectFile::LoadCommandInfo command_info;
-    typedef std::vector<command_info> commands;
-    typedef std::vector<command_info>::const_iterator const_iterator;
-    const_iterator it =
+    //typedef std::vector<command_info> commands;
+    //typedef std::vector<command_info>::const_iterator const_iterator;
+    auto it =
         std::find_if(obj.begin_load_commands(), obj.end_load_commands(),
                      [](const command_info &info){
                          return
@@ -638,7 +639,7 @@ struct objectfile_image : image {
 	, symbols_(sym::read(*ptr))
 	, sections_(sec::read(*ptr))
 	, binary_(move(ptr))
-    {}
+        {std::cout<<"hello from objectfileimage constructor\n";}
     std::string arch() const { return arch_; }
     uint64_t entry() const { return entry_; }
     const std::vector<seg::segment>& segments() const { return segments_; }

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -69,8 +69,8 @@ std::vector<MachOObjectFile::LoadCommandInfo> load_commands(const MachOObjectFil
 
 const pe32plus_header* getPE32PlusHeader(const COFFObjectFile& obj) {
     uint64_t cur_ptr = 0;
-    const char * buf = (obj.getData()).data();
-    const uint8_t * start = reinterpret_cast<const uint8_t *>(buf);
+    const char *buf = (obj.getData()).data();
+    const uint8_t *start = reinterpret_cast<const uint8_t *>(buf);
     uint8_t b0 = start[0];
     uint8_t b1 = start[1];
     if (b0 == 0x4d && b1 == 0x5a) { // check if this is a PE/COFF file
@@ -108,83 +108,15 @@ using namespace llvm;
 using namespace llvm::object;
 
 struct segment {
-    template <typename T>
-    segment(const Elf_Phdr_Impl<T>& hdr, int pos)
-        : offset_(hdr.p_offset)
-        , addr_(hdr.p_vaddr)
-        , size_(hdr.p_filesz)
-        , is_readable_(hdr.p_flags & ELF::PF_R)
-        , is_writable_(hdr.p_flags & ELF::PF_W)
-        , is_executable_(hdr.p_flags & ELF::PF_X) {
-        std::ostringstream oss;
-        oss << std::setfill('0') << std::setw(2) << pos ;
-        name_ = oss.str();
-    }
-
-    segment(const MachO::segment_command &s) {
-        init_macho_segment(s);
-    }
-
-    segment(const MachO::segment_command_64 &s) {
-        init_macho_segment(s);
-    }
-
-    segment(const pe32_header &hdr, const coff_section &s)
-        : name_(s.Name)
-        , offset_(static_cast<uint32_t>(s.PointerToRawData))
-        , addr_(static_cast<uint32_t>(s.VirtualAddress + hdr.ImageBase))
-        , size_(static_cast<uint32_t>(s.SizeOfRawData))
-        , is_readable_(static_cast<uint32_t>(s.Characteristics) &
-                       COFF::IMAGE_SCN_MEM_READ)
-        , is_writable_(static_cast<uint32_t>(s.Characteristics) &
-		       COFF::IMAGE_SCN_MEM_WRITE)
-	, is_executable_(static_cast<uint32_t>(s.Characteristics) &
-			 COFF::IMAGE_SCN_MEM_EXECUTE)
-    {}
-
-    segment(const pe32plus_header &hdr, const coff_section &s)
-        : name_(s.Name)
-        , offset_(static_cast<uint64_t>(s.PointerToRawData))
-	, addr_(static_cast<uint64_t>(s.VirtualAddress + hdr.ImageBase))
-        , size_(static_cast<uint64_t>(s.SizeOfRawData))
-        , is_readable_(static_cast<uint64_t>(s.Characteristics) &
-                       COFF::IMAGE_SCN_MEM_READ)
-        , is_writable_(static_cast<uint64_t>(s.Characteristics) &
-                       COFF::IMAGE_SCN_MEM_WRITE)
-        , is_executable_(static_cast<uint64_t>(s.Characteristics) &
-                         COFF::IMAGE_SCN_MEM_EXECUTE)
-    {}
-
-    const std::string& name() const { return name_; }
-    uint64_t offset() const { return offset_; }
-    uint64_t addr() const { return addr_; }
-    uint64_t size() const { return size_; }
-    bool is_readable() const { return is_readable_; }
-    bool is_writable() const { return is_writable_; }
-    bool is_executable() const { return is_executable_; }
-
-private:
-
-    template <typename S>
-    void init_macho_segment(const S &s) {
-        name_ = s.segname;
-        offset_ = s.fileoff;
-        addr_ = s.vmaddr;
-        size_ = s.filesize;
-        is_readable_ = s.initprot & MachO::VM_PROT_READ;
-        is_writable_ = s.initprot & MachO::VM_PROT_WRITE;
-        is_executable_ = s.initprot & MachO::VM_PROT_EXECUTE;
-    }
-
-private:
-    std::string name_;
-    uint64_t offset_;
-    uint64_t addr_;
-    uint64_t size_;
-    bool is_readable_;
-    bool is_writable_;
-    bool is_executable_;
+    std::string name;
+    uint64_t offset;
+    uint64_t addr;
+    uint64_t size;
+    bool is_readable;
+    bool is_writable;
+    bool is_executable;
 };
+
 
 template<typename T>
 std::vector<segment> read(const ELFObjectFile<T>& obj) {
@@ -194,10 +126,26 @@ std::vector<segment> read(const ELFObjectFile<T>& obj) {
     segments.reserve(std::distance(begin, end));
     for (int pos = 0; begin != end; ++begin, ++pos) {
         if (begin -> p_type == ELF::PT_LOAD) {
-            segments.push_back(segment(*begin, pos));
-        }
+	    std::ostringstream oss;
+	    oss << std::setfill('0') << std::setw(2) << pos;
+	    segments.push_back(segment{oss.str(), 
+			begin->p_offset,
+			begin->p_vaddr, 
+			begin->p_filesz, 
+			static_cast<bool>(begin->p_flags & ELF::PF_R), 
+			static_cast<bool>(begin->p_flags & ELF::PF_W), 
+			static_cast<bool>(begin->p_flags & ELF::PF_X)});
+	}
     }
     return segments;
+}
+
+template <typename S>
+segment make_segment(const S &s) {
+    return segment{s.segname, s.fileoff, s.vmaddr, s.filesize,
+	    static_cast<bool>(s.initprot & MachO::VM_PROT_READ),
+	    static_cast<bool>(s.initprot & MachO::VM_PROT_WRITE),
+	    static_cast<bool>(s.initprot & MachO::VM_PROT_EXECUTE)};
 }
 
 std::vector<segment> read(const MachOObjectFile& obj) {
@@ -207,54 +155,53 @@ std::vector<segment> read(const MachOObjectFile& obj) {
     for (std::size_t i = 0; i < cmds.size(); ++i) {
         command_info info = cmds.at(i);
         if (info.C.cmd == MachO::LoadCommandType::LC_SEGMENT_64)
-            segments.push_back(segment(obj.getSegment64LoadCommand(info)));
+            segments.push_back(make_segment(obj.getSegment64LoadCommand(info)));
         if (info.C.cmd == MachO::LoadCommandType::LC_SEGMENT)
-            segments.push_back(segment(obj.getSegmentLoadCommand(info)));
+            segments.push_back(make_segment(obj.getSegmentLoadCommand(info)));
     }
     return segments;
 }
 
-std::vector<segment> readPE32(const COFFObjectFile& obj) {
-    std::vector<segment> segments;
-    const pe32_header *pe32;
-    if (error_code err = obj.getPE32Header(pe32))
-	llvm_binary_fail(err);
-
-    for (auto it = obj.begin_sections();
-	 it != obj.end_sections(); ++it) {
-	const coff_section *s = obj.getCOFFSection(it);
-	uint32_t c = static_cast<uint32_t>(s->Characteristics);
-	if ( c & COFF::IMAGE_SCN_CNT_CODE ||
-	     c & COFF::IMAGE_SCN_CNT_INITIALIZED_DATA ||
-	     c & COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA )
-	    segments.push_back(segment(*pe32, *s));
-    }
-    return segments;
+template <typename T>
+segment make_segment(T image_base, const coff_section &s) {
+    return segment{s.Name, 
+	    static_cast<T>(s.PointerToRawData),
+	    static_cast<T>(s.VirtualAddress + image_base),
+	    static_cast<T>(s.SizeOfRawData),
+	    static_cast<bool>((s.Characteristics) &
+			      COFF::IMAGE_SCN_MEM_READ),
+	    static_cast<bool>((s.Characteristics) &
+			      COFF::IMAGE_SCN_MEM_WRITE),
+	    static_cast<bool>((s.Characteristics) &
+			      COFF::IMAGE_SCN_MEM_EXECUTE)};
 }
 
-std::vector<segment> readPE32Plus(const COFFObjectFile& obj) {
+template <typename T>
+std::vector<segment> readPE(const COFFObjectFile& obj, const T image_base) {
     std::vector<segment> segments;
-    const pe32plus_header *pe32plus = utils::getPE32PlusHeader(obj);
-    if (!pe32plus)
-	llvm_binary_fail("Failed to extract PE32+ header");
-
     for (auto it = obj.begin_sections();
          it != obj.end_sections(); ++it) {
         const coff_section *s = obj.getCOFFSection(it);
-        uint64_t c = static_cast<uint64_t>(s->Characteristics);
+        T c = static_cast<T>(s->Characteristics);
         if ( c & COFF::IMAGE_SCN_CNT_CODE ||
              c & COFF::IMAGE_SCN_CNT_INITIALIZED_DATA ||
              c & COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA )
-            segments.push_back(segment(*pe32plus, *s));
+            segments.push_back(make_segment<T>(image_base, *s));
     }
     return segments;
 }
 
 std::vector<segment> read(const COFFObjectFile& obj) {
     if (obj.getBytesInAddress() == 4) {
-	return readPE32(obj);
+	const pe32_header *pe32;
+	if (error_code err = obj.getPE32Header(pe32))
+	    llvm_binary_fail(err);
+	return readPE<uint32_t>(obj, pe32->ImageBase);
     } else {
-	return readPE32Plus(obj);
+	const pe32plus_header *pe32plus = utils::getPE32PlusHeader(obj);
+        if (!pe32plus)
+            llvm_binary_fail("Failed to extract PE32+ header");
+	return readPE<uint64_t>(obj, pe32plus->ImageBase);
     }
 }
 
@@ -264,49 +211,40 @@ namespace sym {
 using namespace llvm;
 using namespace llvm::object;
 
+typedef SymbolRef::Type kind_type;
+
 struct symbol {
-    typedef SymbolRef::Type kind_type;
-
-    symbol(const SymbolRef& sym, uint64_t addr, uint64_t size)
-        : symbol(sym) {
-        addr_ = addr;
-        size_ = size;
-    }
-
-    explicit symbol(const SymbolRef& sym) {
-        StringRef name;
-        if(error_code err = sym.getName(name))
-            llvm_binary_fail(err);
-        this->name_ = name.str();
-
-        if (error_code err = sym.getType(this->kind_))
-            llvm_binary_fail(err);
-
-        if (error_code err = sym.getAddress(this->addr_))
-            llvm_binary_fail(err);
-
-        if (error_code err = sym.getSize(this->size_))
-            llvm_binary_fail(err);
-    }
-
-
-    const std::string& name() const { return name_; }
-    kind_type kind() const { return kind_; }
-    uint64_t addr() const { return addr_; }
-    uint64_t size() const { return size_; }
-private:
-    std::string name_;
-    kind_type kind_;
-    uint64_t addr_;
-    uint64_t size_;
+    std::string name;
+    kind_type kind;
+    uint64_t addr;
+    uint64_t size;
 };
 
+symbol make_symbol(const SymbolRef &sym) {
+    StringRef name;
+    if(error_code err = sym.getName(name))
+	llvm_binary_fail(err);
+    
+    kind_type kind;
+    if (error_code err = sym.getType(kind))
+	llvm_binary_fail(err);
+
+    uint64_t addr;
+    if (error_code err = sym.getAddress(addr))
+	llvm_binary_fail(err);
+
+    uint64_t size;
+    if (error_code err = sym.getSize(size))
+	llvm_binary_fail(err);
+    return symbol{name.str(), kind, addr, size};
+}
+
 template <typename OutputIterator>
-OutputIterator read(symbol_iterator begin,
-                    symbol_iterator end,
-                    OutputIterator out) {
+OutputIterator read(symbol_iterator begin, 
+		    symbol_iterator end,
+		    OutputIterator out) {
     return std::transform(begin, end, out,
-                          [](const SymbolRef& s) { return symbol(s); });
+			  [](const SymbolRef& s) { return make_symbol(s); });
 }
 
 std::vector<symbol> read(const ObjectFile& obj) {
@@ -321,52 +259,19 @@ std::vector<symbol> read(const ObjectFile& obj) {
     return symbols;
 }
 
+symbol make_symbol(const SymbolRef& sym, uint64_t addr, uint64_t size) {
+    StringRef name;
+    if(error_code err = sym.getName(name))
+	llvm_binary_fail(err);
 
-std::vector<symbol> readPE32Plus(const COFFObjectFile& obj) {
-    std::vector<symbol> symbols;
-
-    const pe32plus_header *pe32plus = utils::getPE32PlusHeader(obj);
-    if (!pe32plus)
-	llvm_binary_fail("Failed to extract PE32+ header");
-
-    for (auto it = obj.begin_symbols(); it != obj.end_symbols(); ++it) {
-	auto sym = obj.getCOFFSymbol(it);
-
-	if (!sym) llvm_binary_fail("not a coff symbol");
-
-	const coff_section *sec = nullptr;
-	if (sym->SectionNumber == COFF::IMAGE_SYM_UNDEFINED)
-	    continue;
-
-	if (error_code ec = obj.getSection(sym->SectionNumber, sec))
-	    llvm_binary_fail(ec);
-
-	if (!sec) continue;
-
-	uint64_t size = (sec->VirtualAddress + sec->SizeOfRawData) - sym->Value;
-
-	for (auto it = obj.begin_symbols(); it != obj.end_symbols(); ++it) {
-	    auto next = obj.getCOFFSymbol(it);
-	    if (next->SectionNumber == sym->SectionNumber) {
-                auto new_size = next->Value > sym->Value ?
-                    next->Value - sym->Value : size;
-                size = new_size < size ? new_size : size;
-	    }
-	}
-
-	auto addr = sec->VirtualAddress + pe32plus->ImageBase + sym->Value;
-	symbols.push_back(symbol(*it,addr,size));
-    }
-    return symbols;
+    kind_type kind;
+    if (error_code err = sym.getType(kind))
+	llvm_binary_fail(err);
+    return symbol{name.str(), kind, addr, size};
 }
 
-std::vector<symbol> readPE32(const COFFObjectFile& obj) {
+std::vector<symbol> read(const COFFObjectFile& obj, const uint64_t image_base) {
     std::vector<symbol> symbols;
-
-    const pe32_header *pe32;
-    if (error_code err = obj.getPE32Header(pe32))
-        llvm_binary_fail(err);
-
     for (auto it = obj.begin_symbols(); it != obj.end_symbols(); ++it) {
         auto sym = obj.getCOFFSymbol(it);
 
@@ -392,17 +297,23 @@ std::vector<symbol> readPE32(const COFFObjectFile& obj) {
             }
         }
 
-        auto addr = sec->VirtualAddress + pe32->ImageBase + sym->Value;
-        symbols.push_back(symbol(*it,addr,size));
+        auto addr = sec->VirtualAddress + image_base + sym->Value;
+        symbols.push_back(make_symbol(*it,addr,size));
     }
     return symbols;
 }
 
 std::vector<symbol> read(const COFFObjectFile& obj) {
     if (obj.getBytesInAddress() == 4) {
-	return readPE32(obj);
+	const pe32_header *pe32;
+	if (error_code err = obj.getPE32Header(pe32))
+	    llvm_binary_fail(err);
+	return read(obj, pe32->ImageBase);
     } else {
-	return readPE32Plus(obj);
+	const pe32plus_header *pe32plus = utils::getPE32PlusHeader(obj);
+	if (!pe32plus)
+	    llvm_binary_fail("Failed to extract PE32+ header");
+	return read(obj, pe32plus->ImageBase);
     }
 }
 
@@ -434,28 +345,27 @@ using namespace llvm;
 using namespace llvm::object;
 
 struct section {
-    explicit section(const SectionRef& sec) {
-        StringRef name;
-        if(error_code err = sec.getName(name))
-            llvm_binary_fail(err);
-        this->name_ = name.str();
-        if (error_code err = sec.getAddress(this->addr_))
-            llvm_binary_fail(err);
-
-        if (error_code err = sec.getSize(this->size_))
-            llvm_binary_fail(err);
-    }
-    const std::string& name() const { return name_; }
-    uint64_t addr() const { return addr_; }
-    uint64_t size() const { return size_; }
-
-private:
-    std::string name_;
-    uint64_t addr_;
-    uint64_t size_;
+    std::string name;
+    uint64_t addr;
+    uint64_t size;
 };
 
-std::vector<section> read(const ObjectFile& obj) {
+section make_section(const SectionRef &sec) {
+    StringRef name;
+    if (error_code err = sec.getName(name))
+	llvm_binary_fail(err);
+    
+    uint64_t addr;
+    if (error_code err = sec.getAddress(addr))
+	llvm_binary_fail(err);
+
+    uint64_t size;
+    if (error_code err = sec.getSize(size))
+	llvm_binary_fail(err);
+    return section{name.str(), addr, size};
+}
+
+std::vector<section> read(const ObjectFile &obj) {
     int size = utils::distance(obj.begin_sections(),
                                obj.end_sections());
     std::vector<section> sections;
@@ -463,8 +373,37 @@ std::vector<section> read(const ObjectFile& obj) {
     std::transform(obj.begin_sections(),
                    obj.end_sections(),
                    std::back_inserter(sections),
-                   [](const SectionRef& s) { return section(s); });
+                   [](const SectionRef& s) { return make_section(s); });
     return sections;
+}
+
+section make_section(const coff_section &s, const uint64_t image_base) {
+    return section{s.Name, s.VirtualAddress + image_base, s.SizeOfRawData};
+}
+
+template <typename T>
+std::vector<section> readPE(const COFFObjectFile &obj, const T image_base) {
+    std::vector<section> sections;
+    for (auto it = obj.begin_sections();
+         it != obj.end_sections(); ++it) {
+        const coff_section *s = obj.getCOFFSection(it);
+        sections.push_back(make_section(*s, image_base));
+    }
+    return sections;
+} 
+
+std::vector<section> read(const COFFObjectFile& obj) {
+    if (obj.getBytesInAddress() == 4) {
+	const pe32_header *pe32;
+	if (error_code err = obj.getPE32Header(pe32))
+	    llvm_binary_fail(err);
+	return readPE(obj, pe32->ImageBase);
+    } else {
+	const pe32plus_header *pe32plus = utils::getPE32PlusHeader(obj);
+	if (!pe32plus)
+	    llvm_binary_fail("Failed to extract PE32+ header");
+	return readPE(obj, pe32plus->ImageBase);
+    }    
 }
 
 } //namespace sec
@@ -519,31 +458,13 @@ uint64_t image_entry(const COFFObjectFile& obj) {
             llvm_binary_fail("PE header not found");
         return hdr->AddressOfEntryPoint;
     } else {
-	// llvm version 3.4 doesn't support pe32plus_header,
-        // but in version 3.5 it does. So, later one will be
-        // able to write obj->getPE32PlusHeader(hdr) for 64-bit files.
-        uint64_t cur_ptr = 0;
-        const char * buf = (obj.getData()).data();
-        const uint8_t *start = reinterpret_cast<const uint8_t *>(buf);
-        uint8_t b0 = start[0];
-        uint8_t b1 = start[1];
-        if (b0 == 0x4d && b1 == 0x5a) { // Check if this is a PE/COFF file.
-            // A pointer at offset 0x3C points to the PE header.
-            cur_ptr += *reinterpret_cast<const uint16_t *>(start + 0x3c);
-            // Check the PE magic bytes.
-            if (std::memcmp(start + cur_ptr, "PE\0\0", 4) != 0)
-                llvm_binary_fail("PE header not found");
-            cur_ptr += 4; // Skip the PE magic bytes.
-            cur_ptr += sizeof(coff_file_header);
-	    const pe32plus_header *hdr =
-                reinterpret_cast<const pe32plus_header *>(start + cur_ptr);
-	    if (hdr->Magic == 0x20b)
-                return hdr->AddressOfEntryPoint;
-            else
-                llvm_binary_fail("PEplus header not found");
-        } else {
-            llvm_binary_fail("PEplus header not found");
-        }
+	const pe32plus_header *hdr = utils::getPE32PlusHeader(obj);
+	if (!hdr)
+	    llvm_binary_fail("Failed to extract PE32+ header");
+	if (hdr->Magic == 0x20b)
+	    return hdr->AddressOfEntryPoint;
+	else
+	    llvm_binary_fail("PEplus header not found");
     }
 };
 

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -39,7 +39,8 @@ content_iterator<T>& operator++(content_iterator<T>& a) {
 
 }} //namespace llvm::object
 
-
+//! Use anonymous namespace if enclosing functions are not used
+//! outside of the module
 namespace utils {
 using namespace llvm;
 using namespace llvm::object;
@@ -61,6 +62,12 @@ std::vector<MachOObjectFile::LoadCommandInfo> load_commands(const MachOObjectFil
 } // namespace utils
 
 namespace {
+//! using directive inside of unnamed namespace actually polutes the whole
+//! (global) namespace that follows after the using.
+//! also it is not really needed.
+//! finally, it is better not to use using directives (not using declarations)
+//! at all in general, and in header files in general, as their precise meaning
+//! depends on where and how your header would be included.
 using namespace llvm;
 
 template<typename Derived, typename Base>
@@ -95,6 +102,7 @@ std::vector<segment> read(const ELFObjectFile<T>& obj) {
     auto end = obj.getELFFile()->program_header_end();
     std::vector<segment> segments;
     segments.reserve(std::distance(begin, end));
+    //! do not comment out code (and commit it)
     //auto current = begin;
     for (int pos = 0; begin != end; ++begin, ++pos) {
         if (begin -> p_type == ELF::PT_LOAD) {

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -144,7 +144,7 @@ std::vector<segment> read(const MachOObjectFile& obj) {
 
 template <typename T>
 segment make_segment(T image_base, const coff_section &s) {
-    return segment{s.Name, 
+    return segment{s.Name,
 	    static_cast<T>(s.PointerToRawData),
 	    static_cast<T>(s.VirtualAddress + image_base),
 	    static_cast<T>(s.SizeOfRawData),
@@ -241,7 +241,7 @@ section make_section(const SectionRef &sec) {
 
 std::vector<section> read(const ObjectFile &obj) {
     auto size = std::distance(obj.sections().begin(),
-                             obj.sections().end());
+                              obj.sections().end());
     std::vector<section> sections;
     sections.reserve(size);
 
@@ -260,6 +260,9 @@ using namespace llvm::object;
 
 struct image {
     virtual uint64_t entry() const = 0;
+    //! we need to change this member function to return std::string
+    //! instead of LLVM specific ArchType. That will make our image
+    //! abstraction totally independent of LLVM
     virtual Triple::ArchType arch() const = 0;
     virtual const std::vector<seg::segment>& segments() const = 0;
     virtual const std::vector<sym::symbol>& symbols() const = 0;
@@ -334,6 +337,7 @@ protected:
     std::vector<seg::segment> segments_;
     std::vector<sym::symbol> symbols_;
     std::vector<sec::section> sections_;
+    //! woow? why is it public?
 public:
     std::unique_ptr<T> binary_;
 };

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -39,10 +39,16 @@ content_iterator<T>& operator++(content_iterator<T>& a) {
 
 }} //namespace llvm::object
 
+
 namespace utils {
 using namespace llvm;
 using namespace llvm::object;
 
+//! this function essentially translates an object of type
+//! iterator_range<MachOObjectFile::load_command_iterator> to an object of type
+//! std::vector<MachOObjectFile::LoadCommandInfo>
+//! that is later only used for iteration in a very weird way.
+//! to conclude we don't need this function at all
 std::vector<MachOObjectFile::LoadCommandInfo> load_commands(const MachOObjectFile& obj) {
     std::vector<MachOObjectFile::LoadCommandInfo> cmds;
     iterator_range<MachOObjectFile::load_command_iterator> info_list = obj.load_commands();

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -275,8 +275,8 @@ std::vector<segment> read(const COFFObjectFile& obj) {
 	    llvm_binary_fail(ec);
 	return readPE<uint32_t>(obj, pe32->ImageBase);
     } else {
-        uint64_t image_base = getPE32PlusEntry(obj);
-        return readPE<uint64_t>(obj, image_base);
+        const pe32plus_header *pe32 = utils::getPE32PlusHeader(obj);
+        return readPE<uint64_t>(obj, pe32->ImageBase);
     }
 }
 

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -190,13 +190,6 @@ std::vector<llvm::object::section_iterator> sections(const COFFObjectFile &obj) 
     }
     return sections;     
 }
-
-uint64_t getPE32PlusImageBase(const COFFObjectFile &obj) {
-    pe32plus = utils::getPE32PlusHeader(obj);
-    if (!pe32plus)
-        llvm_binary_fail("Failed to extract PE32+ header");
-    
-}
 #endif
 
 template<typename T>

--- a/plugins/llvm/llvm_disasm.cpp
+++ b/plugins/llvm/llvm_disasm.cpp
@@ -146,7 +146,10 @@ public:
             return {nullptr, bap_disasm_unsupported_target};
         }
 
-
+        //! instead of using explcit typenames we can switch to `auto`
+        //! and backport it to LLVM-3.4 version. This comment extends to all
+        //! typerenaming changes in the local scope (i.e., in the scope that allows
+        //! usage of `auto` instead of type)
         std::unique_ptr<llvm::MCRelocationInfo>
             rel_info(target->createMCRelocationInfo(triple, *ctx));
 
@@ -156,13 +159,16 @@ public:
             return {nullptr, bap_disasm_unsupported_target};
         }
 
+        //! concerning using `std::move` here, we can make this change
+        //! external to the constructor by overloading the `move`
+        //! (non-std) function for the two kinds of smart pointers
         std::unique_ptr<llvm::MCSymbolizer>
             symbolizer(target->createMCSymbolizer(
                            triple,
                            nullptr, // getOpInfo
                            nullptr, // SymbolLookUp
                            nullptr, // DisInfo
-                           &*ctx, std::move(rel_info))); 
+                           &*ctx, std::move(rel_info)));
 
         if (!symbolizer) {
             if (debug_level > 0)
@@ -222,15 +228,15 @@ public:
 
     void step(int64_t pc) {
         mcinst.clear();
-        uint64_t size = 0;        
-	    
+        uint64_t size = 0;
+
         auto status = llvm::MCDisassembler::SoftFail;
         int off = pc - mem.base;
         int len = mem.loc.len - off;
 
 	if (len > 0) {
 	    auto data = llvm::ArrayRef<uint8_t>((const uint8_t*)&mem.data[mem.loc.off+off], len);
-	       
+
 	    status = dis->getInstruction
 		(mcinst, size, data, pc,
 		 (debug_level > 2 ? llvm::errs() : llvm::nulls()),
@@ -239,8 +245,8 @@ public:
 
 	if (off < mem.loc.len && size == 0) {
             size += 1;
-        } 
-        
+        }
+
         location loc = {off, (int)size};
 
         if (status == llvm::MCDisassembler::Success) {
@@ -363,17 +369,17 @@ private:
     pred_fun fun_of_pred(bap_disasm_insn_p_type pred) const {
         using namespace llvm;
         switch (pred) {
-            case is_return : return &MCInstrDesc::isReturn;
-            case is_call   : return &MCInstrDesc::isCall;
-            case is_barrier: return &MCInstrDesc::isBarrier;
-            case is_terminator: return &MCInstrDesc::isTerminator;
-            case is_branch: return &MCInstrDesc::isBranch;
-            case is_indirect_branch : return &MCInstrDesc::isIndirectBranch;
-            case is_conditional_branch : return &MCInstrDesc::isConditionalBranch;
-            case is_unconditional_branch : return &MCInstrDesc::isUnconditionalBranch;
-            case may_load : return &MCInstrDesc::mayLoad;
-            case may_store : return &MCInstrDesc::mayStore;
-            default : return nullptr;
+        case is_return : return &MCInstrDesc::isReturn;
+        case is_call   : return &MCInstrDesc::isCall;
+        case is_barrier: return &MCInstrDesc::isBarrier;
+        case is_terminator: return &MCInstrDesc::isTerminator;
+        case is_branch: return &MCInstrDesc::isBranch;
+        case is_indirect_branch : return &MCInstrDesc::isIndirectBranch;
+        case is_conditional_branch : return &MCInstrDesc::isConditionalBranch;
+        case is_unconditional_branch : return &MCInstrDesc::isUnconditionalBranch;
+        case may_load : return &MCInstrDesc::mayLoad;
+        case may_store : return &MCInstrDesc::mayStore;
+        default : return nullptr;
         }
     }
 

--- a/plugins/llvm/llvm_disasm.cpp
+++ b/plugins/llvm/llvm_disasm.cpp
@@ -13,7 +13,12 @@
 #include <llvm/Target/TargetInstrInfo.h>
 
 #include <cstring>
+#include <cstdint>
+#include <limits>
+#include <typeinfo>
 #include <iostream>
+
+
 
 #include "disasm.hpp"
 #include "llvm_disasm.h"
@@ -31,6 +36,11 @@ void initialize_llvm() {
 }
 
 using pred_fun = std::function<bool(const llvm::MCInstrDesc&)>;
+
+bool ends_with(const std::string& str, const std::string &suffix) {
+    auto n = str.length(), m = suffix.length();
+    return n >= m && str.compare(n-m,m,suffix) == 0;
+}
 
 class MemoryObject : public llvm::MemoryObject {
     memory mem;
@@ -95,6 +105,7 @@ static const bap_disasm_insn_p_type supported[] = {
     may_store
 };
 
+
 class llvm_disassembler : public disassembler_interface {
     shared_ptr<const llvm::MCRegisterInfo>  reg_info;
     shared_ptr<const llvm::MCInstrInfo>     ins_info;
@@ -108,6 +119,7 @@ class llvm_disassembler : public disassembler_interface {
     table ins_tab, reg_tab;
     llvm::MCInst mcinst;
     insn current;
+    std::vector<int> prefixes;
 
 
     llvm_disassembler(int debug_level)
@@ -133,6 +145,7 @@ public:
                 output_error(triple, cpu, "target not found", error);
             return {NULL, bap_disasm_unsupported_target};
         }
+
 
         // target's createMC* functions allocates a new instance each time:
         // cf., Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -245,6 +258,7 @@ public:
         self->dis = dis;
         self->ins_tab = self->create_table(ins_info->getNumOpcodes(), ins_info);
         self->reg_tab = self->create_table(reg_info->getNumRegs(), reg_info);
+        self->init_prefixes();
         return {self, 0};
     }
 
@@ -261,34 +275,60 @@ public:
         mem.reset(new MemoryObject(m));
     }
 
-    void step(int64_t pc) {
+    bool is_prefix() const {
+        return std::binary_search(prefixes.begin(),
+                                  prefixes.end(),
+                                  current.code);
+    }
+
+    void step(uint64_t pc) {
         mcinst.clear();
-        uint64_t size = 0;
-        auto status = dis->getInstruction
-            (mcinst, size, *mem, pc,
-             (debug_level > 2 ? llvm::errs() : llvm::nulls()),
-             llvm::nulls());
+        auto base = mem->getBase();
 
-        int off = (int)(pc - mem->getBase());
-
-        if (off < mem->getExtent() && size == 0) {
-            size += 1;
-        }
-
-        location loc = {off, (int)size};
-
-        if (status == llvm::MCDisassembler::Success) {
-            if (debug_level > 1) {
-                std::cerr << "read: '" << get_asm() << "'\n";
-            }
-            current = valid_insn(loc);
+        if (pc < base) {
+            current = invalid_insn(location{0,1});
+        } else if (pc > base + mem->getExtent()) {
+            auto off = static_cast<int>(mem->getExtent() - 1);
+            current = invalid_insn(location{off,1});
         } else {
-            if (debug_level > 0)
-                std::cerr << "failed to decode insn at"
-                          << " pc " << pc
-                          << " offset " << off
-                          << " skipping " << size << " bytes\n";
-            current = invalid_insn(loc);
+            uint64_t size = 0;
+            auto status = dis->getInstruction
+                (mcinst, size, *mem, pc,
+                 (debug_level > 2 ? llvm::errs() : llvm::nulls()),
+                 llvm::nulls());
+
+            location loc = {
+                static_cast<int>(pc - base),
+                static_cast<int>(size)
+            };
+
+            if (status == llvm::MCDisassembler::Success) {
+                if (debug_level > 1) {
+                    std::cerr << "read: '" << get_asm() << "'\n";
+                }
+                current = valid_insn(loc);
+                if (is_prefix() && size != 0) {
+                    step(pc+size);
+
+                    // a standalone prefix is not a valid instruction
+                    if (current.loc.len == 0) {
+                        current = invalid_insn(loc);
+                    }
+
+                    // a prefix to invalid instruction is invalid instruction
+                    if (current.code != 0) {
+                        location ext = {loc.off, loc.len + current.loc.len};
+                        current = valid_insn(ext);
+                    }
+                }
+            } else {
+                if (debug_level > 0)
+                    std::cerr << "failed to decode insn at"
+                              << " pc " << pc
+                              << " offset " << loc.off
+                              << " skipping " << loc.len << " bytes\n";
+                current = invalid_insn(loc);
+            }
         }
     }
 
@@ -309,10 +349,10 @@ public:
 
     // invalid instruction doesn't satisfy any predicate except is_invalid.
     bool satisfies(bap_disasm_insn_p_type p) const {
-        bool current_invalid = current.code == 0;
+        auto current_is_invalid = current.code == 0;
         if (p == is_invalid) {
-            return current_invalid;
-        } else if (current_invalid) {
+            return current_is_invalid;
+        } else if (current_is_invalid) {
             return false;
         } else if (p == is_true) {
             return true;
@@ -335,6 +375,7 @@ public:
         }
         return false;
     }
+
 
 private:
     insn valid_insn(location loc) const {
@@ -436,6 +477,13 @@ private:
         return {p, size};
     }
 
+    void init_prefixes() {
+        for (int i = 0; i < ins_info->getNumOpcodes(); i++) {
+            if (ends_with(ins_info->getName(i), "_PREFIX")) {
+                prefixes.push_back(i);
+            }
+        }
+    }
 };
 
 struct create_llvm_disassembler : disasm_factory {

--- a/plugins/llvm/llvm_disasm.cpp
+++ b/plugins/llvm/llvm_disasm.cpp
@@ -197,7 +197,6 @@ public:
             return {nullptr, bap_disasm_unsupported_target};
         }
 
-        // TODO
         dis->setSymbolizer(std::move(symbolizer));
 
         shared_ptr<llvm_disassembler> self(new llvm_disassembler(debug_level));

--- a/plugins/llvm/llvm_disasm.cpp
+++ b/plugins/llvm/llvm_disasm.cpp
@@ -67,7 +67,7 @@ public:
 
 class llvm_disassembler;
 
-static void output_error(const char *triple, const char *cpu,
+static void output_error(std::string triple, const char *cpu,
                          std::string error, std::string tail="") {
     std::cerr
         << "llvm_disasm: failed to create llvm_disassmbler for:\n"
@@ -115,12 +115,18 @@ class llvm_disassembler : public disassembler_interface {
 
 public:
     static result<llvm_disassembler>
-    create(const char *triple, const char *cpu, int debug_level) {
+    create(const char *name, const char *cpu, int debug_level) {
         std::string error;
+        llvm::Triple t(llvm::Triple::normalize(name));
+        std::string triple = t.getTriple();
 
         // returned value is not allocted
         const llvm::Target *target =
-            llvm::TargetRegistry::lookupTarget(triple, error);
+            llvm::TargetRegistry::lookupTarget(name,t,error);;
+
+        if (!target) {
+            target = llvm::TargetRegistry::lookupTarget("", t, error);
+        }
 
         if (!target) {
             if (debug_level > 0)

--- a/plugins/warn_unused/warn_unused_main.ml
+++ b/plugins/warn_unused/warn_unused_main.ml
@@ -51,11 +51,11 @@ let solve prog seeds = (object
 end)#run prog seeds
 
 let marker unchecked = object
-  inherit Term.mapper
+  inherit Term.mapper as super
   method! map_term cls t =
     if Set.mem unchecked (Term.tid t)
     then Term.set_attr t Term.dead ()
-    else t
+    else super#map_term cls t
 end
 
 let printer unchecked = object

--- a/setup.ml.in
+++ b/setup.ml.in
@@ -75,11 +75,11 @@ let llvm var () : unit =
        let llvm_config = BaseEnv.var_get "llvm_config" in
        let llvm_version = BaseEnv.var_get "llvm_version" in
        let extract v =
-         OASISExec.run_read_one_line ~ctxt llvm_config ["--"^v] in 
+	 OASISExec.run_read_one_line ~ctxt llvm_config ["--"^v] in 
        if llvm_version > "3.4" && var = "ldflags"
        then extract var ^ extract "system-libs"
        else extract var) |>
-  definition_end
+    definition_end
 
 let cxx_flags () : unit =
   BaseEnv.var_define

--- a/src/bap_mc.ml
+++ b/src/bap_mc.ml
@@ -1,9 +1,9 @@
 open Core_kernel.Std
-open Or_error
 open Format
 open Bap.Std
 open Bap_plugins.Std
 open Mc_options
+include Self()
 
 exception Bad_user_input
 exception Bad_insn of mem * int * int
@@ -17,11 +17,9 @@ module Program(Conf : Mc_options.Provider) = struct
   open Conf
   module Dis = Disasm_expert.Basic
 
-  let no_disassembly state (start_addr, boff) =
-    let mem = Dis.memory state in
-    let addr = Addr.((Dis.addr state) - start_addr) in
-    let stop = (Addr.to_int addr |> ok_exn) in
-    raise (Bad_insn (mem, boff, stop))
+  let bad_insn addr state mem start =
+    let stop = Addr.(Dis.addr state - addr |> to_int |> ok_exn) in
+    raise (Bad_insn (Dis.memory state, start, stop))
 
   let escape_0x =
     String.substr_replace_all ~pattern:"0x" ~with_:"\\x"
@@ -68,7 +66,7 @@ module Program(Conf : Mc_options.Provider) = struct
   let print_insn_size should_print mem =
     if should_print then
       let len = Memory.length mem in
-      printf "%#x\n" len
+      printf "%#x@\n" len
 
   let print_insn insn_formats insn =
     let insn = Insn.of_basic insn in
@@ -94,7 +92,7 @@ module Program(Conf : Mc_options.Provider) = struct
         printf "%s" @@ String.concat ~sep:"\n"
           (List.map bs ~f:(Blk.to_bytes ~fmt)))
 
-  let make_print arch mem insn =
+  let print arch mem insn =
     let module Target = (val target_of_arch arch) in
     print_insn_size options.show_insn_size mem;
     print_insn options.insn_formats insn;
@@ -102,47 +100,32 @@ module Program(Conf : Mc_options.Provider) = struct
     print_bir Target.lift mem insn;
     if options.show_kinds then print_kinds insn
 
-  let check max_insn counter = match max_insn with
-    | None -> true
-    | Some max_insn -> counter < max_insn
-
-  let step print state mem insn (addr, counter) =
-    if (check options.max_insn counter) then (
-      print mem insn;
-      Dis.step state (Dis.addr state, counter+1)
-    ) else Dis.stop state (Dis.addr state, counter)
-
   let main () =
     let arch = match Arch.of_string options.arch with
       | None -> raise Unknown_arch
       | Some arch -> arch in
-    let extension = match Arch.addr_size arch with
+    let size = match Arch.addr_size arch with
       | `r32 -> ":32"
       | `r64 -> ":64" in
-    let addr = Addr.of_string (options.addr ^ extension) in
-    let print =
-      make_print arch in
+    let addr = Addr.of_string (options.addr ^ size) in
     let input = read_input options.src in
+    let mem = create_memory arch input addr in
     let backend = options.disassembler in
     Dis.with_disasm ~backend (Arch.to_string arch) ~f:(fun dis ->
-        let invalid state mem pos = no_disassembly state pos in
-        let pos, dis_insn_count  =
-          Dis.run dis ~return:(fun x -> x)
-            ~stop_on:[`Valid] ~invalid
-            ~hit:(step print) ~init:(addr, 0)
-            (create_memory arch input addr) in
-        let bytes_disassembled = Addr.(pos - addr) |> Addr.to_int |> ok_exn in
-        let len = String.length input in
-        match options.max_insn with
-        | None ->
-          if bytes_disassembled <> len then
-            raise (Trailing_data (len - bytes_disassembled));
-          return 0
-        | _ -> return 0)
+        let bytes = Dis.run dis mem ~return:ident ~init:0
+            ~stop_on:[`Valid] ~invalid:(bad_insn addr)
+            ~hit:(fun state mem insn bytes ->
+                print arch mem insn;
+                if options.only_one then Dis.stop state bytes
+                else Dis.step state (bytes + Memory.length mem)) in
+        match String.length input - bytes with
+        | 0 -> Or_error.return ()
+        | _ when options.only_one -> Or_error.return ()
+        | n -> raise (Trailing_data n))
 end
 
 let format_info get_fmts =
-  get_fmts () |> List.map  ~f:fst3 |> String.concat ~sep:", "
+  get_fmts () |> List.map ~f:fst3 |> String.concat ~sep:", "
 
 let print_data_formats data_type =
   let print = Bap_format_printer.run `writers in
@@ -206,18 +189,12 @@ module Cmdline = struct
          info ["show-bir"] ~doc)
 
   let addr =
-    let doc = "Specify an address of first byte, as though \
-               the instructions occur at a certain address, \
-               and accordingly interpreted. Be careful that \
-               you appropriately use 0x prefix for hex and \
-               leave it without for decimal." in
+    let doc = "Specify an address of first byte" in
     Arg.(value & opt  string "0x0" &  info ["addr"] ~doc)
 
-  let max_insns =
-    let doc = "Specify a number of instructions to disassemble.\
-               Good for ensuring that only one instruction is ever\
-               lifted or disassembled from a byte blob. Default is all" in
-    Arg.(value & opt (some int) None & info ["max-insns"] ~doc)
+  let only_one =
+    let doc = "Stop after the first instruction is decoded" in
+    Arg.(value & flag & info ["only-one"] ~doc)
 
   let create a b c d e f g h i j =
     Mc_options.Fields.create a b c d e f g h i j
@@ -253,9 +230,9 @@ module Cmdline = struct
              bap-mc  --show-inst --show-bil");
         `S "SEE ALSO";
         `P "llvm-mc"] in
-    Term.(const create $(disassembler ()) $src $addr $max_insns $arch $show_insn_size
+    Term.(const create $(disassembler ()) $src $addr $only_one $arch $show_insn_size
           $insn_formats $bil_formats $bir_formats $show_kinds),
-    Term.info "bap-mc" ~doc ~man ~version:Config.version
+    Term.info "bap-mc" ~doc ~man ~version
 
   let exitf n =
     kfprintf (fun ppf -> pp_print_newline ppf (); exit n) err_formatter
@@ -282,8 +259,8 @@ let start options =
 let _main : unit =
   Log.start ();
   let argv = Bap_plugin_loader.run Sys.argv in
-  try match Cmdline.parse argv >>= start with
-    | Ok _ -> exit 0
+  try match Or_error.(Cmdline.parse argv >>= start) with
+    | Ok () -> exit 0
     | Error err -> exitf 64 "%s\n" Error.(to_string_hum err)
   with
   | Bad_user_input ->
@@ -292,6 +269,7 @@ let _main : unit =
   | Unknown_arch ->
     exitf 64 "Unknown architecture. Supported architectures:\n%s" @@
     String.concat ~sep:"\n" @@ List.map Arch.all ~f:Arch.to_string
+  | Trailing_data 1 -> exitf 65 "the last byte wasn't disassembled"
   | Trailing_data left ->
     exitf 65 "%d bytes were left non disassembled" left
   | Create_mem err ->

--- a/src/mc_options.ml
+++ b/src/mc_options.ml
@@ -4,7 +4,7 @@ type t = {
   disassembler : string;
   src : string option;
   addr : string;
-  max_insn : int option;
+  only_one : bool;
   arch : string;
   show_insn_size : bool;
   insn_formats : string list;

--- a/tools/oasis_sections.ml
+++ b/tools/oasis_sections.ml
@@ -34,12 +34,18 @@ let features args =
   then header :: everything_except disabled_args
   else header :: selected enabled args
 
+let special_args =
+  List.concat @@ List.map (fun f -> [enabled^f; disabled^f])
+    ["docs"; "tests"; "llvm-static"; "debug"]
+
 let filtered args =
   let enabled_args = selected enabled args in
   let disabled_args = selected disabled args in
-  List.(filter (fun arg -> not (mem arg (
-      map (fun f -> enabled^f) enabled_args @
-      map (fun f -> disabled^f) disabled_args))) args)
+  List.(filter (fun arg ->
+      mem arg special_args ||
+      not (mem arg (
+          map (fun f -> enabled^f) enabled_args @
+          map (fun f -> disabled^f) disabled_args))) args)
 
 let main args =
   match args with


### PR DESCRIPTION
> Mahomet made the people believe that he would call a hill to him, and from the top of it offer up his prayers, for the observers of his law. The people assembled; Mahomet called the hill to come to him, again and again; and when the hill stood still, he was never a whit abashed, but said, If the hill will not come to Mahomet, Mahomet will go to the hill

So, since you're not moving the branch to me, I will move to you. For the future, a branch for the review, should be based on top of the branch to which you make a PR. By based upon, I mean, that at least that it must be merged. Using git rebase is an extra courtesy :) 

For you it means, that you need pull all changes from upstream/master to your review branch.

Now to the review. I added my review comments directly in the code, they are prefixed by a special `//!` comment sign. Please make sure that you addressed all of them. I split my review comments into several commits. Some commits actually makes the change that I want you to make (usually these changes are just reverts). 

You can pull this branch into your working branch, and then fix the issues. Or you can do whatever suits you better. But make sure, that all comments are addressed. We will use this PR for more discussion. Feel free to ask questions here by adding more github comments. 

The overall feeling of the code change shows, that the amount of changes between 3.4 and 3.8 is not that big, and mostly concerns names, not semantics. That means, that there is no need to create `_legacy` files, and we can actually apply locally an `if/def` based on LLVM version (defined in`llvm/include/config.h` file). The general direction is to minimize and localize actual changeset, by using clever tricks, such as function overloading, using declarations and typedefs. It looks like, that most of the changes can be easily backported back to llvm-3.4 version. 

The strategy for you is the following. Install both llvm versions on your maching, and compile for both of them, using if/def macro. Then apply different code transformations to minimize the part under the if/def guards. 
